### PR TITLE
Fix file detection for --config

### DIFF
--- a/server/providers/lib/linters.js
+++ b/server/providers/lib/linters.js
@@ -11,6 +11,18 @@ const default_luacheck_executor = path_1.resolve(__dirname, '../../../3rd/luache
 const luacheck_regex = /^(.+):(\d+):(\d+)-(\d+): \(([EW])(\d+)\) (.+)$/;
 const defaultOpt = ['-m', '-t', '--no-self', '--no-color', '--codes', '--ranges', '--formatter', 'plain'];
 
+function isFileSync(aPath) {
+    try {
+        return fs_1.statSync(aPath).isFile();
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            return false;
+        } else {
+            throw e;
+        }
+    }
+}
+
 class Luacheck {
     constructor(coder) {
         this.coder = coder;
@@ -20,8 +32,8 @@ class Luacheck {
         const settings = this.coder.settings.luacheck;
         let args = [];
 
-        if (fs_1.exists(path_1.resolve(settings.configFilePath, ".luacheckrc"))) {
-            args.push('--config', settings.configFilePath);
+        if (isFileSync(path_1.resolve(settings.configFilePath, ".luacheckrc"))) {
+            args.push('--config', path_1.resolve(settings.configFilePath, ".luacheckrc"));
         } else {
             args.push('--no-config');
         }


### PR DESCRIPTION
While trying to setup my workspace, I noticed that LuaCoderAssist didn't seem to care about my config file.

Path.resolve would automaticlaly append the rc file at the end and see if that file exists, and then it wouldn't append it for the command line.

Scenario 1: configFilePath = "C:/vtmods/"
File Exists: C:/vtmods/.luacheckrc
Cannot load config file C:/vtmods/

Scenario 2: configFilePath = "C:/vtmods/.luacheckrc
File doesn't exist C:/vtmods/.luacheckrc/.luacheckrc

During my testing, fs_1.exists() also had very inconsistent behavior and would fail to see files that existed, and the function is deprecated to begin with, so i changed it for an alternate function that does the same.

Note: Config file support adds some complications to the extension: 
1) If a config file has max_line_length declared, it will be ignored as you enforces the command line version in settings. (which override config). Workaround: Set setting to 0. There should probably be a note about this behavior in the settings comment.
2) exclude_files seems to be exhibiting weird behavior when trying to exclude folders. Files that should be excluded are still being linted and reported on. Ignoring the files in the extension settings is not an option as I still want the other features of the extension in those files. Simply disable the linting on them, which is what exclude_files should do.