### PR TITLE
Don't ignore default .luacheckrc

### DIFF
--- a/server/providers/lib/linters.js
+++ b/server/providers/lib/linters.js
@@ -9,7 +9,7 @@ const symbol_manager_1 = require('./symbol-manager');
 // default to 64-bit windows luacheck.exe, from https://github.com/mpeterv/luacheck/releases
 const default_luacheck_executor = path_1.resolve(__dirname, '../../../3rd/luacheck/luacheck.exe');
 const luacheck_regex = /^(.+):(\d+):(\d+)-(\d+): \(([EW])(\d+)\) (.+)$/;
-const defaultOpt = ['-m', '-t', '--no-self', '--no-color', '--codes', '--ranges', '--formatter', 'plain'];
+const defaultOpt = ['-m', '-t', '--no-color', '--codes', '--ranges', '--formatter', 'plain'];
 
 function isFileSync(aPath) {
     try {
@@ -34,8 +34,6 @@ class Luacheck {
 
         if (isFileSync(path_1.resolve(settings.configFilePath, ".luacheckrc"))) {
             args.push('--config', path_1.resolve(settings.configFilePath, ".luacheckrc"));
-        } else {
-            args.push('--no-config');
         }
 
         if (settings.std.length > 0) {


### PR DESCRIPTION
Luacheck searches for a `.luacheckrc` file by default in specific locations, with the current implementation that behavior is overridden by the command line flag `--no-config` unless you specify a `configFilePath` (which is not that friendly). You need to set this setting for each project, which is not nice or easy to set up.

Also the `--no-self` flag has precedence over any `.luacheckrc` file which is bad for the user, you can't turn this flag off in any way.
As described in [this issue](https://github.com/mpeterv/luacheck/issues/110), CLI arguments are the most relevant arguments, and they will override any configuration provided by the `.luacheckrc` file.

If this behaviors are needed it would be better to put them under boolean settings.