### PR TITLE
Fix backticks in the hover tooltips

### DIFF
--- a/server/providers/hover-provider.js
+++ b/server/providers/hover-provider.js
@@ -53,7 +53,7 @@ class HoverProvider {
         const desc = (override !== undefined) ? symbol.type.variants[override].description : (symbol.type.description || '');
         const link = symbol.type.link;
         const more = (link ? `  \r\n[more...](${link})` : '');
-        return `\`\`\`lua\n${utils.symbolSignature(symbol, override)}\`\`\`` + `\r\n${desc}${more}`;
+        return `\`\`\`lua\n${utils.symbolSignature(symbol, override)}\r\n\`\`\`` + `\r\n${desc}${more}`;
     }
 };
 


### PR DESCRIPTION
I am seeing backticks in the function signature on VS Code version 1.34.0-insider on Windows using the Remote - WSL extension.

Before: 
![markdown-bug](https://user-images.githubusercontent.com/4096820/57174642-0f7ea180-6e10-11e9-8c5e-2bfb524bbbfa.png)

After: 
![after-fix](https://user-images.githubusercontent.com/4096820/57174649-2cb37000-6e10-11e9-84ed-55223af392e9.png)
