### PR TITLE
Better english translation for luacheck.configFilePath description

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
         "LuaCoderAssist.luacheck.configFilePath": {
           "type": "string",
           "default": "",
-          "description": "The path of '.luacheckrc'."
+          "description": "The path of the folder where '.luacheckrc' is stored."
         },
         "LuaCoderAssist.luacheck.keepAfterClosed": {
           "type": "boolean",


### PR DESCRIPTION
https://github.com/liwangqian/LuaCoderAssist/issues/71

https://github.com/liwangqian/LuaCoderAssist/issues/108

People have been struggling to use their own .luacheckrc files. I think a lot of this confusion has to do with the description being used for this setting which asks for the path *to the file* but really wants the path *to the folder that contains the file*.

Translation:
人们一直在努力使用自己的 .luacheckrc 文件。 我认为这种混乱很大程度上与用于此设置的描述有关，该设置要求*到文件*的路径，但实际上需要*到包含该文件的文件夹*的路径。

https://github.com/liwangqian/LuaCoderAssist/blob/6bc32272bc3217c2533d1375f42002c8df195b26/server/providers/lib/linters.js#L52